### PR TITLE
Add Bonjour auto-discovery for Vor instances (Requires Vor ≥1.9.0)

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -16,8 +16,14 @@
 	"runtime": {
 		"type": "node22",
 		"api": "nodejs-ipc",
-		"apiVersion": "0.0.0",
+		"apiVersion": "1.1.0",
 		"entrypoint": "../dist/main.js"
+	},
+	"bonjourQueries": {
+		"bonjour_host": {
+			"type": "vor-osc",
+			"protocol": "udp"
+		}
 	},
 	"legacyIds": [],
 	"manufacturer": "Borealis Solutions",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,5 +1,6 @@
 import type { ModuleInstance } from './main.js'
 import { MessageType, OSCString } from './constants.js'
+import { getTargetHostPort } from './config.js'
 import { OSCClient, OSCType } from 'ts-osc'
 import { InputValue, Regex } from '@companion-module/base'
 
@@ -130,12 +131,13 @@ export function UpdateActions(self: ModuleInstance): void {
 
 function sendSimpleMessage(msgType: MessageType, instance: ModuleInstance) {
 	const address = constructAddress(msgType, instance.config.osc_id)
+	const { host, port } = getTargetHostPort(instance.config)
 
-	const client = new OSCClient(instance.config.host, instance.config.port)
+	const client = new OSCClient(host, port)
 
 	client.send(address, OSCType.Null, null)
 
-	instance.log('debug', `Sent ${address} to ${instance.config.host}`)
+	instance.log('debug', `Sent ${address} to ${host}:${port}`)
 }
 
 function sendAttributeMessage(
@@ -144,8 +146,9 @@ function sendAttributeMessage(
 	value: string | number | InputValue | undefined,
 ) {
 	const address = constructAddress(msgType, instance.config.osc_id)
+	const { host, port } = getTargetHostPort(instance.config)
 
-	const client = new OSCClient(instance.config.host, instance.config.port)
+	const client = new OSCClient(host, port)
 
 	if (typeof value === 'string') {
 		client.send(address, OSCType.String, value)
@@ -153,7 +156,7 @@ function sendAttributeMessage(
 		client.send(address, OSCType.Integer, value)
 	}
 
-	instance.log('debug', `Sent ${address} to ${instance.config.host} with attribute: ${value} (as a ${typeof value})`)
+	instance.log('debug', `Sent ${address} to ${host}:${port} with attribute: ${value} (as a ${typeof value})`)
 }
 
 function constructAddress(msgType: MessageType, osc_id: number) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,9 @@
 import { Regex, type SomeCompanionConfigField, InstanceStatus, DropdownChoice } from '@companion-module/base'
-import { ModuleInstance } from './main.js'
+import type { ModuleInstance } from './main.js'
 import { getLocalInterfaceIPs } from './discopixel/sACNReceiver/sacnReceiver.js'
 
 export interface ModuleConfig {
+	bonjour_host: string | undefined
 	host: string
 	port: number
 	osc_id: number
@@ -17,12 +18,19 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 
 	return [
 		{
+			type: 'bonjour-device',
+			id: 'bonjour_host',
+			label: 'Vor Instance',
+			width: 6,
+		},
+		{
 			type: 'textinput',
 			id: 'host',
 			label: 'Vor Host (IP or Hostname)',
 			width: 8,
 			default: '127.0.0.1',
 			regex: Regex.HOSTNAME,
+			isVisible: (options) => !options.bonjour_host,
 		},
 		{
 			type: 'number',
@@ -32,14 +40,7 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			default: 3049,
 			min: 101,
 			max: 65535,
-			// regex: Regex.PORT,
-		},
-		// @ts-expect-error - Static Text not defined in the type for some reason, but it is valid for alignment.
-		{
-			type: 'static-text',
-			id: 'null1',
-			label: '',
-			width: 8,
+			isVisible: (options) => !options.bonjour_host,
 		},
 		{
 			type: 'number',
@@ -75,27 +76,48 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			isVisible: (options) => !!options.use_rec_sACN,
 			width: 6,
 			choices: localIPChoices,
-			default: 'Pick an interface IP...',
+			default: localIPChoices.length > 0 ? localIPChoices[0].id : '',
+			allowCustom: true,
 		},
 	]
 }
 
+/**
+ * Parse the effective host and port from the module config.
+ * If a Bonjour device is selected, its value is "host:port" and takes priority.
+ * Otherwise, the manual host and port fields are used.
+ */
+export function getTargetHostPort(config: ModuleConfig): { host: string; port: number } {
+	if (config.bonjour_host) {
+		const parts = config.bonjour_host.split(':')
+		return {
+			host: parts[0],
+			port: parts.length > 1 ? Number(parts[1]) : config.port,
+		}
+	}
+	return { host: config.host, port: config.port }
+}
+
 export function validateConfig(instance: ModuleInstance): boolean {
 	const config = instance.config
+	const { host, port } = getTargetHostPort(config)
 
-	try {
-		if (!config.host) {
-			throw Error('IP or Hostname is mandatory!')
-		}
-		if (!config.port) {
-			throw Error('Destination Port Num is mandatory!')
-		}
-		if (config.use_rec_sACN && !config.sacn_universe) {
-			throw Error('sACN Universe must be specified when sACN recording status is enabled!')
-		}
-	} catch (e: any) {
-		instance.updateStatus(InstanceStatus.BadConfig, e.toString())
+	if (!host) {
+		instance.updateStatus(InstanceStatus.BadConfig, 'IP or Hostname is mandatory!')
 		return false
 	}
+	if (!port) {
+		instance.updateStatus(InstanceStatus.BadConfig, 'Destination Port Num is mandatory!')
+		return false
+	}
+	if (config.use_rec_sACN && !config.sacn_universe) {
+		instance.updateStatus(
+			InstanceStatus.BadConfig,
+			'sACN Universe must be specified when sACN recording status is enabled!',
+		)
+		return false
+	}
+
+	instance.updateStatus(InstanceStatus.Ok)
 	return true
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { InstanceBase, InstanceStatus, runEntrypoint, SomeCompanionConfigField } from '@companion-module/base'
+import { InstanceBase, runEntrypoint, SomeCompanionConfigField } from '@companion-module/base'
 import { GetConfigFields, type ModuleConfig, validateConfig } from './config.js'
 import { destroyVariableUpdaters, UpdateVariableDefinitions } from './variables.js'
 import { UpgradeScripts } from './upgrades.js'
@@ -15,8 +15,6 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 
 	async init(config: ModuleConfig): Promise<void> {
 		this.config = config
-
-		this.updateStatus(InstanceStatus.Ok)
 
 		this.updateActions() // export actions
 		this.updateFeedbacks() // export feedbacks


### PR DESCRIPTION
- Allow Companion to automatically discover Vor instances on the network via Bonjour
- Add bonjourQueries to manifest for vor-osc UDP service type
- Add bonjour-device config field with isVisible toggles on manual fields
- Add getTargetHostPort() helper to resolve Bonjour vs manual config
- Update actions to route OSC messages through resolved host/port
- Improve config validation to use resolved target and set status on success
- Bump apiVersion from 0.0.0 to 1.1.0